### PR TITLE
Threading Issue Fix

### DIFF
--- a/AutoClicker/MainForm.cs
+++ b/AutoClicker/MainForm.cs
@@ -245,8 +245,19 @@ namespace AutoClicker
 
         private void HandleNextClick(object sender, AutoClicker.NextClickEventArgs e)
         {
-            countdownThread = new Thread(() => CountDown(e.NextClick));
-            countdownThread.Start();
+            if (countdownThread == null)
+            {
+                countdownThread = new Thread(() => CountDown(e.NextClick));
+                countdownThread.Start();
+            }
+            else
+            {
+                countdownThread.Abort();
+                countdownThread = new Thread(() => CountDown(e.NextClick));
+                countdownThread.Start();
+            }
+
+            
         }
 
         private void HandleFinished(object sender, EventArgs e)


### PR DESCRIPTION
Every time a click was handled a new thread was created and the old thread wasn't aborted. After so many threads it through some random exceptions.